### PR TITLE
Updating repo when pulling for development

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Or for development:
 
    pip install -e git+https://github.com/FAST-HEP/fast-plotter.git#egg=fast-plotter
 
-(you may need the `--user` flag)
+(you may need the :code:`--user` flag)
 
 * Free software: Apache Software License 2.0
 

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,9 @@ Or for development:
 
 .. code-block:: bash
 
-   pip install -e git+https://gitlab.cern.ch/fast-hep/public/fast-plotter.git#egg=fast-plotter
+   pip install -e git+https://github.com/FAST-HEP/fast-plotter.git#egg=fast-plotter
 
+(you may need the `--user` flag)
 
 * Free software: Apache Software License 2.0
 


### PR DESCRIPTION
pip install link for development was pointing to GitLab instead of GitHub