### PR TITLE
Fixing bug in dataset_order

### DIFF
--- a/fast_plotter/utils.py
+++ b/fast_plotter/utils.py
@@ -137,6 +137,7 @@ def order_datasets(df, dataset_order, dataset_level="dataset", values="sumw"):
         elif dataset_order == "sum-descending":
             dataset_order = sums.sort_values(
                 by=values, ascending=False).index.tolist()
+        return df.reindex(dataset_order, axis=0, level=dataset_level)
     elif isinstance(dataset_order, list):
         return df.reindex(dataset_order, axis=0, level=dataset_level)
     raise RuntimeError("Bad dataset_order value")


### PR DESCRIPTION
Forgot to add return statement before. If this statement is missing, fast-plotter will crash if the user doesn't specify a dataset_order