### PR TITLE
Calculating relative error for MC from sumw instead of sumw2

### DIFF
--- a/fast_plotter/__main__.py
+++ b/fast_plotter/__main__.py
@@ -88,7 +88,7 @@ def process_one_file(infile, args):
             df_filtered.rename({weight: "sumw"}, axis="columns", inplace=True)
             df_filtered["sumw2"] = df_filtered.sumw
         else:
-            df_filtered = df.filter(like=weight, axis="columns").copy()
+            df_filtered = df.copy()
             if "n" in df.columns:
                 data_rows = mask_rows(df_filtered,
                                       regex=args.data,

--- a/fast_plotter/plotting.py
+++ b/fast_plotter/plotting.py
@@ -283,8 +283,8 @@ def plot_1d_many(df, prefix="", data="data", signal=None, dataset_col="dataset",
             error = "markers"
         else:
             raise RuntimeError(err_msg)
-        if not 'ratio_ylim' in kwargs.keys():
-            kwargs['ratio_ylim'] = [0., 2]
+        if 'ratio_ylim' not in kwargs.keys():
+            kwargs['ratio_ylim'] = [0., 2.]
         plot_ratio(summed_data, summed_sims, x=x_axis,
                    y=y, yerr=yerr, ax=summary_ax, error=error, ylim=kwargs['ratio_ylim'])
     else:

--- a/fast_plotter/utils.py
+++ b/fast_plotter/utils.py
@@ -89,11 +89,17 @@ def split_data_sims(df, data_labels=["data"], dataset_level="dataset"):
     return split_df(df, first_values=data_labels, level=dataset_level)
 
 
-def calculate_error(df, sumw2_label="sumw2", err_label="err", inplace=True):
+def calculate_error(df, sumw2_label="sumw2", err_label="err", inplace=True, do_rel_err=True):
     if not inplace:
         df = df.copy()
+    if do_rel_err:
+        root_n = np.sqrt(df["n"])
     for column in df:
-        if sumw2_label in column:
+        if do_rel_err and column.endswith("sumw"):
+            err_name = column.replace("sumw", err_label)
+            df[err_name] = np.true_divide(df[column], root_n)
+            df[err_name][~np.isfinite(df[err_name])] = np.nan
+        elif not do_rel_err and sumw2_label in column:
             err_name = column.replace(sumw2_label, err_label)
             df[err_name] = np.sqrt(df[column])
     if not inplace:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ def binned_df_dataset_njet():
 
 def test_calculate_error(binned_df_dataset_njet):
     utils.calculate_error(binned_df_dataset_njet)
-    assert all(binned_df_dataset_njet.err == np.sqrt(binned_df_dataset_njet.sumw2))
+    assert all(binned_df_dataset_njet.err == binned_df_dataset_njet.sumw / np.sqrt(binned_df_dataset_njet.n))
 
 
 def test_read_binned_df():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,8 @@ def binned_df_dataset_njet():
 
 def test_calculate_error(binned_df_dataset_njet):
     utils.calculate_error(binned_df_dataset_njet)
-    assert all(binned_df_dataset_njet.err == binned_df_dataset_njet.sumw / np.sqrt(binned_df_dataset_njet.n))
+    assert np.allclose(binned_df_dataset_njet.err.values,
+                       binned_df_dataset_njet.sumw.values / np.sqrt(binned_df_dataset_njet.n.values), equal_nan=True)
 
 
 def test_read_binned_df():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,9 +38,12 @@ def binned_df_dataset_njet():
 
 
 def test_calculate_error(binned_df_dataset_njet):
-    utils.calculate_error(binned_df_dataset_njet)
-    assert np.allclose(binned_df_dataset_njet.err.values,
-                       binned_df_dataset_njet.sumw.values / np.sqrt(binned_df_dataset_njet.n.values), equal_nan=True)
+    df_relative = utils.calculate_error(binned_df_dataset_njet, inplace=False)
+    assert np.allclose(df_relative.err,
+                       np.true_divide(df_relative.sumw, np.sqrt(df_relative.n)), equal_nan=True)
+
+    df_poisson = utils.calculate_error(binned_df_dataset_njet, inplace=False, do_rel_err=False)
+    assert np.allclose(df_poisson.err, np.sqrt(df_poisson.sumw2), equal_nan=True)
 
 
 def test_read_binned_df():


### PR DESCRIPTION
Calculating error as sumw/sqrt(N) where N = unweighted number of events

Currently, this method is forcibly imposed over the previous method that used sumw2.

Not sure how we want to handle things from a user's perspective. Maybe adding a command line argument/config entry which is a flag for whether to do the relative error or not? Then I would have to make sure that variable propagates through all the functions required. Or do I just leave it forcibly imposed?