### PR TITLE
Fixing problem with inconsistent signal line colours

### DIFF
--- a/fast_plotter/plotting.py
+++ b/fast_plotter/plotting.py
@@ -140,7 +140,7 @@ class FillColl(object):
                 width = self.linewidth
                 style = "-"
             else:
-                color = None
+                color = color
                 label = col.name
                 width = 2
                 style = "--"


### PR DESCRIPTION
Fix for https://github.com/FAST-HEP/fast-plotter/issues/42

Very small change, but I think requires a colour to be tied to the signal process (e.g., with an entry in the `dataset_colours` block or in the `dataset_order` block) to work properly. I don't think it will default to using the "original" colours (i.e., from matplotlib's `tab10` colourmap) if neither of the above blocks are specified