### PR TITLE
Try fixing travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
  - "3.6"
  - "3.7"
  - "3.8"
+ - "3.9"
 
 install:
   - pip install -r .requirements_dev.txt
@@ -31,4 +32,4 @@ deploy:
   on:
     tags: true
     repo: FAST-HEP/fast-plotter
-    condition: "$TRAVIS_PYTHON_VERSION == 3.6 && $TRAVIS_TAG =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-rc[0-9]+|[.]dev[0-9]+)?$"
+    condition: "$TRAVIS_PYTHON_VERSION == 3.7 && $TRAVIS_TAG =~ ^v[0-9]+[.][0-9]+[.][0-9]+(-rc[0-9]+|[.]dev[0-9]+)?$"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2020-11-10
+### Fixed
+- Travis deploy to pypi, PR #51
+
 ## [0.9.0] - 2020-11-10
 ### Added
 - Option to control query engine in postproc, PR #49 [@eshwen](https://github.com/eshwen)

--- a/fast_plotter/version.py
+++ b/fast_plotter/version.py
@@ -12,5 +12,5 @@ def split_version(version):
     return tuple(result)
 
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 version_info = split_version(__version__) # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = True
 tag = False
 


### PR DESCRIPTION
There's an issue deploy to pypi within Travis due to Twine on python 3.6, e.g.: https://travis-ci.com/github/FAST-HEP/fast-plotter/jobs/432001636

As a hopefully "quick" fix, I'm switching to deploy from python 3.7