### PR TITLE
Support for line annotations

### DIFF
--- a/fast_plotter/__main__.py
+++ b/fast_plotter/__main__.py
@@ -140,12 +140,12 @@ def process_one_file(infile, args):
 def dress_main_plots(plots, annotations=[], yscale=None, ylabel=None, legend={},
                      limits={}, xtickrotation=None, **kwargs):
     for main_ax, summary_ax in plots.values():
-        add_annotations(annotations, main_ax)
+        add_annotations(annotations, main_ax, summary_ax)
         if yscale:
             main_ax.set_yscale(yscale)
         if ylabel:
             main_ax.set_ylabel(ylabel)
-        main_ax.legend(**legend)
+        main_ax.legend(**legend).set_zorder(20)
         main_ax.grid(True)
         main_ax.set_axisbelow(True)
         for axis, lims in limits.items():

--- a/fast_plotter/plotting.py
+++ b/fast_plotter/plotting.py
@@ -423,6 +423,7 @@ def _merge_datasets(df, style, dataset_col, param_name="_merge_datasets", err_fr
     utils.calculate_error(df, do_rel_err=not err_from_sumw2)
     return df
 
+
 def annotate_lines(cfg, main_ax, summary_ax):
     linename = list(cfg.keys())[0]
     annotDict = cfg[linename]


### PR DESCRIPTION
Adds support for line annotations from config (to e.g. separate out categories, mark out important value, etc)

Example usage:
```
annotations:
        - vlines:
              values: [600]
              axes: ['main','summary']
              style: '--'
              label: 'Overflow bin for fit'
        - vlines:
              values: [200]
              colour: 'red'
        - hlines:
              values: [0.75, 1.25]
              style: '--'
              axes: ['summary']
```
![plot_dataset met--sig_regions_fit--weight_nominal--project_met-yscale_log](https://user-images.githubusercontent.com/43857191/124624799-21877f00-de75-11eb-810e-a56d337e1959.png)

