### PR TITLE
Null poissonian

### DIFF
--- a/fast_plotter/plotting.py
+++ b/fast_plotter/plotting.py
@@ -378,7 +378,8 @@ def plot_1d_many(df, prefix="", data="data", signal=None, dataset_col="dataset",
     for df, combine, style, label, var_name in config:
         if df is None or len(df) == 0:
             continue
-        merged = _merge_datasets(df, combine, dataset_col, param_name=var_name, err_from_sumw2=err_from_sumw2, is_null_poissonian=kwargs['is_null_poissonian'])
+        merged = _merge_datasets(df, combine, dataset_col, param_name=var_name, err_from_sumw2=err_from_sumw2,
+                                 is_null_poissonian=kwargs['is_null_poissonian'])
         actually_plot(merged, x_axis=x_axis, y=y, yerr=yerr, kind=style,
                       label=label, ax=main_ax, dataset_col=dataset_col,
                       dataset_colours=dataset_colours,
@@ -393,9 +394,11 @@ def plot_1d_many(df, prefix="", data="data", signal=None, dataset_col="dataset",
     if summary.startswith("ratio"):
         main_ax.set_xlabel("")
         summed_data = _merge_datasets(
-            in_df_data, "sum", dataset_col=dataset_col, err_from_sumw2=err_from_sumw2, is_null_poissonian=kwargs['is_null_poissonian'])
+            in_df_data, "sum", dataset_col=dataset_col, err_from_sumw2=err_from_sumw2,
+            is_null_poissonian=kwargs['is_null_poissonian'])
         summed_sims = _merge_datasets(
-            in_df_sims, "sum", dataset_col=dataset_col, err_from_sumw2=err_from_sumw2, is_null_poissonian=kwargs['is_null_poissonian'])
+            in_df_sims, "sum", dataset_col=dataset_col, err_from_sumw2=err_from_sumw2,
+            is_null_poissonian=kwargs['is_null_poissonian'])
         if summary == "ratio-error-both":
             error = "both"
         elif summary == "ratio-error-markers":
@@ -412,7 +415,8 @@ def plot_1d_many(df, prefix="", data="data", signal=None, dataset_col="dataset",
     return main_ax, summary_ax
 
 
-def _merge_datasets(df, style, dataset_col, param_name="_merge_datasets", err_from_sumw2=False, is_null_poissonian=False):
+def _merge_datasets(df, style, dataset_col, param_name="_merge_datasets", err_from_sumw2=False,
+                    is_null_poissonian=False):
     if style == "stack":
         df = utils.stack_datasets(df, dataset_level=dataset_col)
     elif style == "sum":

--- a/fast_plotter/plotting.py
+++ b/fast_plotter/plotting.py
@@ -374,10 +374,11 @@ def plot_1d_many(df, prefix="", data="data", signal=None, dataset_col="dataset",
               (in_df_data, plot_data, kind_data, data_legend, "plot_data"),
               (in_df_signal, plot_signal, kind_signal, "Signal", "plot_signal"),
               ]
+    kwargs.setdefault("is_null_poissonian", False)
     for df, combine, style, label, var_name in config:
         if df is None or len(df) == 0:
             continue
-        merged = _merge_datasets(df, combine, dataset_col, param_name=var_name, err_from_sumw2=err_from_sumw2)
+        merged = _merge_datasets(df, combine, dataset_col, param_name=var_name, err_from_sumw2=err_from_sumw2, is_null_poissonian=kwargs['is_null_poissonian'])
         actually_plot(merged, x_axis=x_axis, y=y, yerr=yerr, kind=style,
                       label=label, ax=main_ax, dataset_col=dataset_col,
                       dataset_colours=dataset_colours,
@@ -392,9 +393,9 @@ def plot_1d_many(df, prefix="", data="data", signal=None, dataset_col="dataset",
     if summary.startswith("ratio"):
         main_ax.set_xlabel("")
         summed_data = _merge_datasets(
-            in_df_data, "sum", dataset_col=dataset_col, err_from_sumw2=err_from_sumw2)
+            in_df_data, "sum", dataset_col=dataset_col, err_from_sumw2=err_from_sumw2, is_null_poissonian=kwargs['is_null_poissonian'])
         summed_sims = _merge_datasets(
-            in_df_sims, "sum", dataset_col=dataset_col, err_from_sumw2=err_from_sumw2)
+            in_df_sims, "sum", dataset_col=dataset_col, err_from_sumw2=err_from_sumw2, is_null_poissonian=kwargs['is_null_poissonian'])
         if summary == "ratio-error-both":
             error = "both"
         elif summary == "ratio-error-markers":
@@ -411,7 +412,7 @@ def plot_1d_many(df, prefix="", data="data", signal=None, dataset_col="dataset",
     return main_ax, summary_ax
 
 
-def _merge_datasets(df, style, dataset_col, param_name="_merge_datasets", err_from_sumw2=False):
+def _merge_datasets(df, style, dataset_col, param_name="_merge_datasets", err_from_sumw2=False, is_null_poissonian=False):
     if style == "stack":
         df = utils.stack_datasets(df, dataset_level=dataset_col)
     elif style == "sum":
@@ -419,7 +420,7 @@ def _merge_datasets(df, style, dataset_col, param_name="_merge_datasets", err_fr
     elif style:
         msg = "'{}' must be either 'sum', 'stack' or None. Got {}"
         raise RuntimeError(msg.format(param_name, style))
-    utils.calculate_error(df, do_rel_err=not err_from_sumw2)
+    utils.calculate_error(df, do_rel_err=not err_from_sumw2, is_null_poissonian=is_null_poissonian)
     return df
 
 

--- a/fast_plotter/utils.py
+++ b/fast_plotter/utils.py
@@ -91,7 +91,7 @@ def split_data_sims(df, data_labels=["data"], dataset_level="dataset"):
     return split_df(df, first_values=data_labels, level=dataset_level)
 
 
-def calculate_error(df, sumw2_label="sumw2", err_label="err", inplace=True, do_rel_err=True):
+def calculate_error(df, sumw2_label="sumw2", err_label="err", inplace=True, do_rel_err=True, is_null_poissonian=False):
     if not inplace:
         df = df.copy()
     if do_rel_err:
@@ -105,6 +105,10 @@ def calculate_error(df, sumw2_label="sumw2", err_label="err", inplace=True, do_r
         elif not do_rel_err and sumw2_label in column:
             err_name = column.replace(sumw2_label, err_label)
             df[err_name] = np.sqrt(df[column])
+    if is_null_poissonian:
+        print(err_name)
+        print(df.loc[df[err_name]<=0])
+        df[err_name] = df[err_name].apply(lambda x: x if x > 0 else 1.15)
     if not inplace:
         return df
 

--- a/fast_plotter/utils.py
+++ b/fast_plotter/utils.py
@@ -102,10 +102,12 @@ def calculate_error(df, sumw2_label="sumw2", err_label="err", inplace=True, do_r
             errs = np.true_divide(df[column], root_n)
             errs.loc[~np.isfinite(errs)] = np.nan
             df[err_name] = errs
-        else:
-        #elif not do_rel_err and sumw2_label in column:
+        elif not do_rel_err and sumw2_label in column:
             err_name = column.replace(sumw2_label, err_label)
             df[err_name] = np.sqrt(df[column])
+        else:
+            err_name = ""
+            continue
         if is_null_poissonian:
             df[err_name] = df[err_name].apply(lambda x: x if x > 1.15 else np.sqrt(1.15**2+x**2))
     if not inplace:

--- a/fast_plotter/utils.py
+++ b/fast_plotter/utils.py
@@ -102,13 +102,12 @@ def calculate_error(df, sumw2_label="sumw2", err_label="err", inplace=True, do_r
             errs = np.true_divide(df[column], root_n)
             errs.loc[~np.isfinite(errs)] = np.nan
             df[err_name] = errs
-        elif not do_rel_err and sumw2_label in column:
+        else:
+        #elif not do_rel_err and sumw2_label in column:
             err_name = column.replace(sumw2_label, err_label)
             df[err_name] = np.sqrt(df[column])
-    if is_null_poissonian:
-        print(err_name)
-        print(df.loc[df[err_name]<=0])
-        df[err_name] = df[err_name].apply(lambda x: x if x > 0 else 1.15)
+        if is_null_poissonian:
+            df[err_name] = df[err_name].apply(lambda x: x if x > 1.15 else np.sqrt(1.15**2+x**2))
     if not inplace:
         return df
 

--- a/fast_plotter/utils.py
+++ b/fast_plotter/utils.py
@@ -106,7 +106,6 @@ def calculate_error(df, sumw2_label="sumw2", err_label="err", inplace=True, do_r
             err_name = column.replace(sumw2_label, err_label)
             df[err_name] = np.sqrt(df[column])
         else:
-            err_name = ""
             continue
         if is_null_poissonian:
             df[err_name] = df[err_name].apply(lambda x: x if x > 1.15 else np.sqrt(1.15**2+x**2))


### PR DESCRIPTION
The minimum error of any bin in `n` should be 1.15, which is the poissonian error for 0 counts. We don't want this error to be plotted for every bin in our standard plots, but it can be turned on in the config with:
`is_null_poissonian: True`.

We won't want this for standard plots like below, but is useful for e.g. mountain range plots, or fit-binned plots. Obviously better solution would be explicitly calculating the poisson error and plotting asymmetric errors, but this is better than nothing. I'm taking the quad sum of 1.15 and the 'default' error so that the error is > 1.15 for nonzero yields. Ideally would find a way to ignore the underflow bin.

I'm also not sure whether this minimum value should be applied to monte-carlo, as I am currently, or just data. 

With and without this option, and also with autoscaling also turned on, which looks better:
![plot_dataset met--test--weight_nominal--project_met-yscale_log](https://user-images.githubusercontent.com/43857191/125071653-7d3e4c00-e0b1-11eb-926b-be918ceae9b8.png)
![plot_dataset met--sig_regions_fit--weight_nominal--project_met-yscale_log](https://user-images.githubusercontent.com/43857191/125072771-e7a3bc00-e0b2-11eb-9795-08d2efbc6941.png)
![plot_dataset met--sig_regions_fit--weight_nominal--project_met-yscale_log](https://user-images.githubusercontent.com/43857191/125073047-55e87e80-e0b3-11eb-9b10-375c0db8e9ac.png)



